### PR TITLE
Fix decoding WebSocketEvents with unicode chars

### DIFF
--- a/src/test/java/org/fanout/gripcontrol/ChannelTest.java
+++ b/src/test/java/org/fanout/gripcontrol/ChannelTest.java
@@ -1,7 +1,7 @@
+package org.fanout.gripcontrol;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
-
-import org.fanout.gripcontrol.*;
 
 public class ChannelTest {
     @Test

--- a/src/test/java/org/fanout/gripcontrol/GripControlTest.java
+++ b/src/test/java/org/fanout/gripcontrol/GripControlTest.java
@@ -1,12 +1,14 @@
-import org.junit.Test;
-import static org.junit.Assert.*;
+package org.fanout.gripcontrol;
 
-import java.util.*;
-import org.fanout.gripcontrol.*;
-import javax.xml.bind.DatatypeConverter;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import com.google.gson.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
 
 public class GripControlTest {
     @Test

--- a/src/test/java/org/fanout/gripcontrol/GripControlTest.java
+++ b/src/test/java/org/fanout/gripcontrol/GripControlTest.java
@@ -189,6 +189,32 @@ public class GripControlTest {
         assertEquals(events.get(0).content, "Hello");
     }
 
+    @Test
+    public void testDecodeWebSocketEventsUnicode() {
+        List<WebSocketEvent> events = GripControl.decodeWebSocketEvents("TEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\n");
+        assertEquals(events.size(), 1);
+        assertEquals(events.get(0).type, "TEXT");
+        assertEquals(events.get(0).content, "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל");
+
+        events = GripControl.decodeWebSocketEvents("TEXT fe\r\n😀 Grinning Face.\n😃 Grinning Face with Big Eyes.\n😄 Grinning Face with Smiling Eyes.\n😁 Beaming Face with Smiling Eyes.\n😆 Grinning Squinting Face.\n😅 Grinning Face with Sweat.\n🤣 Rolling on the Floor Laughing.\n😂 Face with Tears of Joy.\r\n");
+        assertEquals(events.size(), 1);
+        assertEquals(events.get(0).type, "TEXT");
+        assertEquals(events.get(0).content, "😀 Grinning Face.\n😃 Grinning Face with Big Eyes.\n😄 Grinning Face with Smiling Eyes.\n😁 Beaming Face with Smiling Eyes.\n😆 Grinning Squinting Face.\n😅 Grinning Face with Sweat.\n🤣 Rolling on the Floor Laughing.\n😂 Face with Tears of Joy.");
+
+        events = GripControl.decodeWebSocketEvents("TEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\nTEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\nTEXT fe\r\n😀 Grinning Face.\n😃 Grinning Face with Big Eyes.\n😄 Grinning Face with Smiling Eyes.\n😁 Beaming Face with Smiling Eyes.\n😆 Grinning Squinting Face.\n😅 Grinning Face with Sweat.\n🤣 Rolling on the Floor Laughing.\n😂 Face with Tears of Joy.\r\nTEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\nTEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\n");
+        assertEquals(events.size(), 5);
+        assertEquals(events.get(0).type, "TEXT");
+        assertEquals(events.get(0).content, "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל");
+        assertEquals(events.get(1).type, "TEXT");
+        assertEquals(events.get(1).content, "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל");
+        assertEquals(events.get(2).type, "TEXT");
+        assertEquals(events.get(2).content, "😀 Grinning Face.\n😃 Grinning Face with Big Eyes.\n😄 Grinning Face with Smiling Eyes.\n😁 Beaming Face with Smiling Eyes.\n😆 Grinning Squinting Face.\n😅 Grinning Face with Sweat.\n🤣 Rolling on the Floor Laughing.\n😂 Face with Tears of Joy.");
+        assertEquals(events.get(3).type, "TEXT");
+        assertEquals(events.get(3).content, "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל");
+        assertEquals(events.get(4).type, "TEXT");
+        assertEquals(events.get(4).content, "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל");
+    }
+
     @Test(expected=IllegalArgumentException.class)
     public void testDecodeWebSocketEventsException1() throws IllegalArgumentException {
         GripControl.decodeWebSocketEvents("TEXT 5");

--- a/src/test/java/org/fanout/gripcontrol/HttpResponseFormatTest.java
+++ b/src/test/java/org/fanout/gripcontrol/HttpResponseFormatTest.java
@@ -1,10 +1,13 @@
-import org.junit.Test;
-import static org.junit.Assert.*;
+package org.fanout.gripcontrol;
 
-import java.util.*;
-import org.fanout.gripcontrol.*;
+import org.junit.Test;
+
 import javax.xml.bind.DatatypeConverter;
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class HttpResponseFormatTest {
     @Test

--- a/src/test/java/org/fanout/gripcontrol/HttpStreamFormatTest.java
+++ b/src/test/java/org/fanout/gripcontrol/HttpStreamFormatTest.java
@@ -1,11 +1,12 @@
-import org.junit.Test;
-import static org.junit.Assert.*;
+package org.fanout.gripcontrol;
 
-import java.util.*;
-import org.fanout.gripcontrol.*;
+import org.junit.Test;
+
 import javax.xml.bind.DatatypeConverter;
 import java.io.UnsupportedEncodingException;
-import java.lang.IllegalArgumentException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class HttpStreamFormatTest {
     @Test

--- a/src/test/java/org/fanout/gripcontrol/ResponseTest.java
+++ b/src/test/java/org/fanout/gripcontrol/ResponseTest.java
@@ -1,9 +1,12 @@
-import org.junit.Test;
-import static org.junit.Assert.*;
+package org.fanout.gripcontrol;
 
-import java.util.*;
-import org.fanout.gripcontrol.*;
+import org.junit.Test;
+
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class ResponseTest {
     @Test

--- a/src/test/java/org/fanout/gripcontrol/UtilitiesTest.java
+++ b/src/test/java/org/fanout/gripcontrol/UtilitiesTest.java
@@ -1,10 +1,11 @@
+package org.fanout.gripcontrol;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
-import org.fanout.gripcontrol.*;
-import java.net.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class UtilitiesTest {
     private static final byte[][] byteTests = {

--- a/src/test/java/org/fanout/gripcontrol/WebSocketEventTest.java
+++ b/src/test/java/org/fanout/gripcontrol/WebSocketEventTest.java
@@ -1,7 +1,8 @@
-import org.junit.Test;
-import static org.junit.Assert.*;
+package org.fanout.gripcontrol;
 
-import org.fanout.gripcontrol.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class WebSocketEventTest {
     @Test

--- a/src/test/java/org/fanout/gripcontrol/WebSocketMessageFormatTest.java
+++ b/src/test/java/org/fanout/gripcontrol/WebSocketMessageFormatTest.java
@@ -1,10 +1,12 @@
-import org.junit.Test;
-import static org.junit.Assert.*;
+package org.fanout.gripcontrol;
 
-import java.util.*;
-import org.fanout.gripcontrol.*;
+import org.junit.Test;
+
 import javax.xml.bind.DatatypeConverter;
 import java.io.UnsupportedEncodingException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class WebSocketMessageFormatTest {
     @Test


### PR DESCRIPTION
Currently `GripControl.decodeWebSocketEvents` fails to correctly parse events which include unicode payloads. The C++ pushpin implementation encodes the content length using the byte count, but the Java String class deals with unicode, so the content length provided by pushpin does not match the length of the String, resulting in `java.lang.StringIndexOutOfBoundsException: String index out of range`.

This PR creates a unit test to repro the issue, and updates the decode method to track the byte offset for counting the content by byte instead of character. This allows the code to properly parse the unicode payloads.

Performance-wise, the method is _slightly_ slower, primarily due to the call to `String.getBytes()`. If the performance impact is concerning, I'm happy to create an overloaded method which works for unicode, to avoid the perf hit on the existing method for anyone who doesn't need unicode support.
>I ran the following test for both the old and new method:
> - passed a non-unicode string so both methods properly decode
> - called the method 1M times to get a measurable duration
> - executed the loop 100 times to get min/avg/max
>
>The results on my laptop were as follows (times in milliseconds):
>```
>Old:   Min: 270.38,  Avg: 298.77,  Max: 698.44
>New:   Min: 389.84,  Avg: 411.60,  Max: 572.71
>```
>
>So on my machine, this works out to an increase of about 112 nanoseconds per call, on average (1M ns / ms & 1M iterations). Obviously this raw number will vary a bit across different hardware.

Commits:
- Fix test packaging & clean up imports
- Add unicode test (failing)
- Fix decoding WebSocketEvents with unicode chars