### PR TITLE
Fix encoding for unicode content length

### DIFF
--- a/src/main/java/org/fanout/gripcontrol/GripControl.java
+++ b/src/main/java/org/fanout/gripcontrol/GripControl.java
@@ -206,7 +206,7 @@ public class GripControl {
         for (WebSocketEvent event : webSocketEvents) {
             out = out + event.type;
             if (event.content != null)
-                out = out + " " + Integer.toString(event.content.length(), 16) + "\r\n" + event.content + "\r\n";
+                out = out + " " + Integer.toString(event.content.getBytes().length, 16) + "\r\n" + event.content + "\r\n";
             else {
                 out = out + "\r\n";
             }

--- a/src/test/java/org/fanout/gripcontrol/GripControlTest.java
+++ b/src/test/java/org/fanout/gripcontrol/GripControlTest.java
@@ -163,6 +163,25 @@ public class GripControlTest {
     }
 
     @Test
+    public void testEncodeWebSocketEventsUnicode() {
+        List<WebSocketEvent> events = new ArrayList<WebSocketEvent>();
+        events.add(new WebSocketEvent("TEXT", "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל"));
+        assertEquals(GripControl.encodeWebSocketEvents(events), "TEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\n");
+
+        events = new ArrayList<WebSocketEvent>();
+        events.add(new WebSocketEvent("TEXT", "😀 Grinning Face.\n😃 Grinning Face with Big Eyes.\n😄 Grinning Face with Smiling Eyes.\n😁 Beaming Face with Smiling Eyes.\n😆 Grinning Squinting Face.\n😅 Grinning Face with Sweat.\n🤣 Rolling on the Floor Laughing.\n😂 Face with Tears of Joy."));
+        assertEquals(GripControl.encodeWebSocketEvents(events), "TEXT fe\r\n😀 Grinning Face.\n😃 Grinning Face with Big Eyes.\n😄 Grinning Face with Smiling Eyes.\n😁 Beaming Face with Smiling Eyes.\n😆 Grinning Squinting Face.\n😅 Grinning Face with Sweat.\n🤣 Rolling on the Floor Laughing.\n😂 Face with Tears of Joy.\r\n");
+
+        events = new ArrayList<WebSocketEvent>();
+        events.add(new WebSocketEvent("TEXT", "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל"));
+        events.add(new WebSocketEvent("TEXT", "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל"));
+        events.add(new WebSocketEvent("TEXT", "😀 Grinning Face.\n😃 Grinning Face with Big Eyes.\n😄 Grinning Face with Smiling Eyes.\n😁 Beaming Face with Smiling Eyes.\n😆 Grinning Squinting Face.\n😅 Grinning Face with Sweat.\n🤣 Rolling on the Floor Laughing.\n😂 Face with Tears of Joy."));
+        events.add(new WebSocketEvent("TEXT", "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל"));
+        events.add(new WebSocketEvent("TEXT", "😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל"));
+        assertEquals(GripControl.encodeWebSocketEvents(events), "TEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\nTEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\nTEXT fe\r\n😀 Grinning Face.\n😃 Grinning Face with Big Eyes.\n😄 Grinning Face with Smiling Eyes.\n😁 Beaming Face with Smiling Eyes.\n😆 Grinning Squinting Face.\n😅 Grinning Face with Sweat.\n🤣 Rolling on the Floor Laughing.\n😂 Face with Tears of Joy.\r\nTEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\nTEXT 69\r\n😍Smiling Face with Heart-Shaped Eyes☼Sun✂︎Scissors💖Heart⛺️sunset🇮🇱דגל ישראל\r\n");
+    }
+
+    @Test
     public void testDecodeWebSocketEvents() throws IllegalArgumentException {
         List<WebSocketEvent> events = GripControl.decodeWebSocketEvents("OPEN\r\nTEXT 5\r\nHello" +
             "\r\nTEXT 0\r\n\r\nCLOSE\r\nTEXT\r\nCLOSE\r\n");


### PR DESCRIPTION
Adding to #1 , this fixes the content length for unicode strings on the encoding side.

- Added a unit test to mirror the decoding tests
- Updated the encode method to get the length from the string's bytes, rather than character length

@harmony7 After this merges, I'm wondering if there will be an updated version available via maven?